### PR TITLE
Support `Link` headers with an `anchor` attribute defined

### DIFF
--- a/test/integration/get.ts
+++ b/test/integration/get.ts
@@ -74,6 +74,31 @@ describe('Issuing a GET request', async () => {
 
   });
 
+  it('should support the HTTP Link header anchors', async () => {
+
+    const resource2 = await ketting.follow('linkHeader');
+    const anchoredLinks = await resource2.links('author', '#article-1');
+
+    expect(anchoredLinks).to.eql([
+      new Link({
+        rel: 'author',
+        baseHref: 'http://localhost:3000/link-header#article-1',
+        href: '/users/jane-doe'
+      }),
+    ]);
+
+    const thirdPartyLinks = await resource2.links('author', 'http://third-party.org/');
+
+    expect(thirdPartyLinks).to.eql([
+      new Link({
+        rel: 'author',
+        baseHref: 'http://third-party.org/',
+        href: '/users/john-doe'
+      }),
+    ]);
+
+  });
+
   it('should throw an exception when no content-type was returned', async () => {
 
     const resource2 = await ketting.follow('no-content-type');

--- a/test/testserver.ts
+++ b/test/testserver.ts
@@ -105,7 +105,9 @@ app.use(
      ctx.response.set('Link', [
        '</hal2.json>; rel="next"',
        '</TheBook/chapter2>; rel="previous"; title*=UTF-8\'de\'n%c3%a4chstes%20Kapitel',
-       '<http://example.org/>; rel="start http://example.net/relation/other"'
+       '<http://example.org/>; rel="start http://example.net/relation/other"',
+       '</users/jane-doe>; rel="author"; anchor="#article-1"',
+       '</users/john-doe>; rel="author"; anchor="http://third-party.org/"',
      ]);
      ctx.response.body = { ok: true };
 


### PR DESCRIPTION
[RFC8288, Section 3.2](https://tools.ietf.org/html/rfc8288#section-3.2) defines the concept of "Link context".

Every link established in an HTTP response has a context URI and a target URI—its source and its target. By default, a link's context URI is the URI established by the application making the request, or if one is not available, the URI that was used to retrieve the entity in which the link exists<sup>[1]</sup>.

However, this context can be overridden by a link's `anchor` attribute. An anchor can point to a fragment in the returned entity (like "the third article in a list of articles") or different URI entirely.

In the same section that defines link context, the specification permits an application to ignore the `anchor` attribute, but if it does so, it must ignore the link entirely.

The current implementation ignores the `anchor` attribute, but it does not ignore the link completely, in violation of the linking specification. This PR adds support for a Link header `anchor` attribute rather than ignoring it.

[1]: https://tools.ietf.org/html/rfc3986#section-5.1 "Reference Resolution"