### PR TITLE
Adding an option to send along Prefer: transclude=rel

### DIFF
--- a/src/follower.ts
+++ b/src/follower.ts
@@ -8,6 +8,7 @@ abstract class Follower<T> implements PromiseLike<T> {
 
   protected prefetchEnabled: boolean;
   protected preferPushEnabled: boolean;
+  protected preferTranscludeEnabled: boolean;
 
   preFetch(): this {
     this.prefetchEnabled = true;
@@ -16,6 +17,11 @@ abstract class Follower<T> implements PromiseLike<T> {
 
   preferPush(): this {
     this.preferPushEnabled = true;
+    return this;
+  }
+
+  preferTransclude(): this {
+    this.preferTranscludeEnabled = true;
     return this;
   }
 
@@ -112,6 +118,9 @@ export class FollowerOne<T = any> extends Follower<Resource<T>> {
     if (this.preferPushEnabled) {
       resource.addNextRefreshHeader('Prefer-Push', this.rel);
     }
+    if (this.preferTranscludeEnabled) {
+      resource.addNextRefreshHeader('Prefer', 'transclude=' + this.rel);
+    }
     const link = await resource.link(this.rel);
     let href;
 
@@ -183,6 +192,9 @@ export class FollowerMany<T = any> extends Follower<Array<Resource<T>>> {
     const resource = await this.resource;
     if (this.preferPushEnabled) {
       resource.addNextRefreshHeader('Prefer-Push', this.rel);
+    }
+    if (this.preferTranscludeEnabled) {
+      resource.addNextRefreshHeader('Prefer', 'transclude=' + this.rel);
     }
 
     const links = await resource.links(this.rel);

--- a/test/unit/follower.ts
+++ b/test/unit/follower.ts
@@ -69,6 +69,19 @@ describe('FollowerOne', () => {
 
   });
 
+  it('should add a Prefer: transclude= header to the next refresh if requested', async() => {
+
+    const fakeResource = getFakeResource();
+    const follower = new FollowerOne(fakeResource, 'rel1');
+    await follower.preferTransclude();
+    expect(
+      (fakeResource as any).nextRefreshHeaders
+    ).to.eql({
+      'Prefer': 'transclude=rel1'
+    });
+
+  });
+
   it('should not prefetch if not requested', async () => {
 
     const fakeResource = getFakeResource();
@@ -136,6 +149,19 @@ describe('FollowerMany', () => {
       (fakeResource as any).nextRefreshHeaders
     ).to.eql({
       'Prefer-Push': 'rel1'
+    });
+
+  });
+
+  it('should add a Prefer: transclude= header to the next refresh if requested', async() => {
+
+    const fakeResource = getFakeResource();
+    const follower = new FollowerMany(fakeResource, 'rel1');
+    await follower.preferTransclude();
+    expect(
+      (fakeResource as any).nextRefreshHeaders
+    ).to.eql({
+      'Prefer': 'transclude=rel1'
     });
 
   });


### PR DESCRIPTION
I'm adding a default way to ketting to tell the server: "Please add all the link entries from this link relationship as hal _embedded items", creating a compound response.

Usage:

```typescript
const itemResources = await resource.followAll('item').preferTransclude()
```