### PR TITLE
Export representos and RepresentorHelper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import * as representor from './representor';
+
 export { default as Ketting, default } from './ketting';
 export { default as Resource } from './resource';
 export { default as Link, LinkNotFound } from './link';
+export { representor };

--- a/src/representor/hal.ts
+++ b/src/representor/hal.ts
@@ -48,9 +48,7 @@ export default class Hal extends Representation<HalBody> {
    * the result.
    */
   protected parse(body: string): HalBody {
-
     return JSON.parse(body);
-
   }
 
   protected parseLinks(body: HalBody): Link[] {

--- a/src/representor/index.ts
+++ b/src/representor/index.ts
@@ -1,0 +1,17 @@
+import Representor from './base';
+import CollectionJsonRepresentor from './collection-json';
+import HalRepresentor from './hal';
+import RepresentorHelper from './helper';
+import HtmlRepresentor from './html';
+import JsonApiRepresentor from './jsonapi';
+import SirenRepresentor from './siren';
+
+export {
+  CollectionJsonRepresentor,
+  HalRepresentor,
+  HtmlRepresentor,
+  JsonApiRepresentor,
+  Representor,
+  RepresentorHelper,
+  SirenRepresentor
+};

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -63,7 +63,6 @@ export default class Resource<TResource = any, TPatch = Partial<TResource>> {
    * Returns a promise that resolves to a parsed json object.
    */
   async get(): Promise<TResource> {
-
     const r = await this.representation();
     return r.getBody();
 


### PR DESCRIPTION
I had to export also the RepresentorHelper because the creation of the representor is handled by the create() method of the RepresentorHelper.