### PR TITLE
State serializers

### DIFF
--- a/src/state/collection-json.ts
+++ b/src/state/collection-json.ts
@@ -12,8 +12,7 @@ export class CjState<T = any> extends BaseState<T> {
 
   serializeBody(): string {
 
-    return JSON.stringify(this.body);
-
+    throw new Error('Reserializing Collection+JSON states is not yet supported. Please log an issue in the Ketting project to help figure out how this should be done');
   }
 
 }

--- a/src/state/html.ts
+++ b/src/state/html.ts
@@ -13,7 +13,7 @@ export class HtmlState extends BaseState<string> {
 
   serializeBody(): string {
 
-    return JSON.stringify(this.body);
+    throw new Error('Reserializing HTML states is not yet supported. Please log an issue in the Ketting project to help figure out how this should be done');
 
   }
 

--- a/src/state/siren.ts
+++ b/src/state/siren.ts
@@ -12,7 +12,7 @@ export class SirenState<T = any> extends BaseState<T> {
 
   serializeBody(): string {
 
-    return JSON.stringify(this.body);
+    throw new Error('Reserializing Siren states is not yet supported. Please log an issue in the Ketting project to help figure out how this should be done');
 
   }
 

--- a/test/unit/state/hal.ts
+++ b/test/unit/state/hal.ts
@@ -179,6 +179,55 @@ describe('HAL representor', () => {
     expect(hal.getEmbedded()).to.eql([]);
 
   });
+
+  it('should correctly reserialize HAL documents', async() => {
+
+    const hal = await callFactory({
+      _links: {
+        author: {
+          href: 'https://evertpot.com/',
+        },
+        foo: [
+          {
+            href: '/bar',
+          },
+          {
+            href: '/bar2',
+          },
+          {
+            href: '/bar3',
+          },
+        ]
+      },
+      happy: 2020,
+    });
+
+    const result = JSON.parse(hal.serializeBody());
+    expect(result).to.eql({
+      _links: {
+        self: {
+          href: 'http://example/',
+        },
+        author: {
+          href: 'https://evertpot.com/',
+        },
+        foo: [
+          {
+            href: '/bar',
+          },
+          {
+            href: '/bar2',
+          },
+          {
+            href: '/bar3',
+          },
+        ]
+      },
+      happy: 2020,
+    });
+
+  });
+
 });
 
 function callFactory(body: any, url = 'http://example/'): Promise<HalState> {


### PR DESCRIPTION
This implements a serializer for HAL.

We're gonna throw exceptions for HTML, Siren and Collection+JSON for now.

I don't have enough real-world experience to make decisions on how this
should be done, or at all. My sense is that these formats are mostly
read-only and instead users should interact with
siren/collection+json/html states through the actions/forms they expose.

So instead we'll leave this open until someone who does have a good idea on how this should be approached comes along. 

Fixes #194 