### PR TITLE
post() is renamed to postFollow() and new post() functionality for forms 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,8 +5,9 @@ ChangeLog
 --------------------------
 
 * `State` is now exported.
-* Added a new `postFollow()` function that takes over the role of `post()`.
-  `post()` is now intended for RPC-like operations and form submissions.
+* #184: Added a new `postFollow()` function that takes over the role of
+  `post()`.  `post()` is now intended for RPC-like operations and form
+  submissions.
 
 
 6.0.0-alpha.1 (2020-05-03)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+6.0.0-alpha.2 (2020-05-03)
+--------------------------
+
+* `State` is now exported.
+* Added a new `postFollow()` function that takes over the role of `post()`.
+  `post()` is now intended for RPC-like operations and form submissions.
+
+
 6.0.0-alpha.1 (2020-05-03)
 --------------------------
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -115,6 +115,10 @@ export default class Client {
 
     let state: State;
 
+    if (!contentType) {
+      return binaryStateFactory(uri, response);
+    }
+
     if (contentType in this.contentTypeMap) {
       state = await this.contentTypeMap[contentType][0](uri, response);
     } else if (contentType.startsWith('text/')) {

--- a/src/http/util.ts
+++ b/src/http/util.ts
@@ -4,8 +4,11 @@ import { Link, Links } from '../link';
 /**
  * Takes a Content-Type header, and only returns the mime-type part.
  */
-export function parseContentType(contentType: string): string {
+export function parseContentType(contentType: string | null): string | null {
 
+  if (!contentType) {
+    return null;
+  }
   if (contentType.includes(';')) {
     contentType = contentType.split(';')[0];
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { default as Resource } from './resource';
 export { Link, LinkNotFound, Links } from './link';
 
 export {
+  State,
   HalState,
   BinaryState,
   JsonApiState,

--- a/test/integration/post-follow.ts
+++ b/test/integration/post-follow.ts
@@ -16,7 +16,7 @@ describe('Issuing a POST request', async () => {
 
   it('should not fail', async () => {
 
-    newResource = await resource.post({
+    newResource = await resource.postFollow({
       body: { title: 'Posted resource' }
     }) as Resource;
 
@@ -40,7 +40,7 @@ describe('Issuing a POST request', async () => {
     const resource400 = await ketting.follow('error400');
     let exception;
     try {
-      await resource400.post({
+      await resource400.postFollow({
         body: {foo: 'bar'}
       });
     } catch (ex) {

--- a/test/unit/resource.ts
+++ b/test/unit/resource.ts
@@ -41,28 +41,38 @@ describe('Resource', () => {
 
   });
 
-  describe('post()', () => {
+  describe('postFollow()', () => {
 
-    it('should return null if 200 OK was returned', async () => {
+    it('should throw an error if 200 OK was returned', async () => {
 
       const res = getFakeResource('https://example.org/200');
-      const result = await res.post({});
-      expect(result).to.eql(null);
+      let err = false;
+      try {
+        await res.postFollow({});
+      } catch (e) {
+        err = true;
+      }
+      expect(err).to.eql(true);
 
     });
 
-    it('should return null if 201 Created was returned and no Location header', async () => {
+    it('should throw an error if 201 Created was returned and no Location header', async () => {
 
       const res = getFakeResource('https://example.org/201');
-      const result = await res.post({});
-      expect(result).to.eql(null);
+      let err = false;
+      try {
+        await res.postFollow({});
+      } catch (e) {
+        err = true;
+      }
+      expect(err).to.eql(true);
 
     });
 
     it('should return a new resource if 201 Created was returned with a new location header', async () => {
 
       const res = getFakeResource('https://example.org/201-loc');
-      const result = await res.post({});
+      const result = await res.postFollow({});
       expect(result!.uri).to.eql('https://evertpot.com/');
 
     });
@@ -70,7 +80,7 @@ describe('Resource', () => {
     it('should return itself if 205 Reset Content was returned', async () => {
 
       const res = getFakeResource('https://example.org/205');
-      const result = await res.post({});
+      const result = await res.postFollow({});
       expect(result).to.equal(res);
 
     });


### PR DESCRIPTION
Since this PR there are now 2 POST related functions:

1. post() - For RPC operations and form submissions, returns a State
2. postFollow() - For creation of new resources. Returns a new Resource.

Fixes #184 