### PR TITLE
exporting resolve from ketting util

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export { default as Resource } from './resource';
 
 export { Link, LinkNotFound, Links } from './link';
 
+export { resolve } from './util/uri';
+
 export {
   State,
   HalState,


### PR DESCRIPTION
- This will allow ketting users to use `.resolve()` to bypass having to generate a new URL for link association. 