### PR TITLE
`cacheState` was never called so embedded requests was not cached

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -172,7 +172,7 @@ export default class Client {
    * This function will also emit 'update' events to resources, and store all
    * embedded states.
    */
-  cacheState(state: State) {
+  cacheState(state: State): void {
 
     this.cache.store(state);
     const resource = this.resources.get(state.uri);

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -275,10 +275,14 @@ export class Resource<T = any> extends EventEmitter {
    *
    * This will update the local state but *not* update the server
    */
-  updateCache(state: State<T>) {
+  updateCache(state: State<T>): void {
 
-    this.client.cache.store(state);
-    this.emit('update', state);
+    this.client.cacheState(state);
+
+    const resource = this.client.resources.get(state.uri);
+    if (!resource) {
+      this.emit('update', state);
+    }
 
   }
 

--- a/test/unit/resource.ts
+++ b/test/unit/resource.ts
@@ -126,6 +126,10 @@ function getFakeResource(uri: string = 'https://example.org/') {
 
   const fakeClient:any = {
 
+    resources: {
+      get: ():false => { return false; },
+    },
+
     fetcher: {
 
       fetch: fakeFetch,


### PR DESCRIPTION
Fixes: https://github.com/badgateway/ketting/issues/229