### PR TITLE
Only alter 'User-Agent' if `client.fetcher.advertiseKetting` is true

### DIFF
--- a/src/http/fetcher.ts
+++ b/src/http/fetcher.ts
@@ -15,6 +15,8 @@ export class Fetcher {
 
   middlewares: [RegExp, FetchMiddleware][] = [];
 
+  advertiseKetting: boolean = true
+
   /**
    * A wrapper for MDN fetch()
    *
@@ -29,7 +31,7 @@ export class Fetcher {
     const mws = this.getMiddlewaresByOrigin(origin);
     mws.push((innerRequest: Request) => {
 
-      if (!innerRequest.headers.has('User-Agent')) {
+      if (!innerRequest.headers.has('User-Agent') && this.advertiseKetting) {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         innerRequest.headers.set('User-Agent', 'Ketting/' + require('../../package.json').version);
       }


### PR DESCRIPTION
When "setting" a `User-Agent` header, some browsers will add `user-agent` to `Access-Control-Request-Headers`, which will require API's to allow `user-agent` in their CORS settings, this behaviour should be possible to deactivate.