### PR TITLE
Call the correct cache updating function.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -157,7 +157,7 @@ export default class Client {
       state = await this.contentTypeMap[contentType][0](uri, response);
     } else if (contentType.startsWith('text/')) {
       state = await textStateFactory(uri, response);
-    } else{
+    } else {
       state = await binaryStateFactory(uri, response);
     }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -277,8 +277,10 @@ export class Resource<T = any> extends EventEmitter {
    */
   updateCache(state: State<T>) {
 
-    this.client.cache.store(state);
-    this.emit('update', state);
+    if (state.uri !== this.uri) {
+      throw new Error('When calling updateCache on a resource, the uri of the State object must match the uri of the Resource');
+    }
+    this.client.cacheState(state);
 
   }
 

--- a/test/unit/resource.ts
+++ b/test/unit/resource.ts
@@ -154,6 +154,7 @@ function getFakeResource(uri: string = 'https://example.org/') {
     getStateForResponse: () => {
 
       return {
+        uri,
         links: new Links('/', [ { href: '/', rel: 'yes', context: '/' }])
       };
 


### PR DESCRIPTION
Refresh was recently refactored to use an internal cache updating
function. Unfortunately this caused embedded resources to not be cached.

Fixes #229