### PR TITLE
Embedded items should only replace cache if they have the same context

### DIFF
--- a/src/cache/forever.ts
+++ b/src/cache/forever.ts
@@ -58,7 +58,16 @@ export class ForeverCache implements StateCache {
   /**
    * Delete a State object from the cache, by its uri
    */
-  delete(uri: string) {
+  delete(uri: string): void {
+    const stateInCache = this.cache.get(uri);
+    if (stateInCache) {
+      for (const embeddedItem of stateInCache.getEmbedded()) {
+        if (embeddedItem.links.defaultContext === uri) {
+          this.cache.delete(embeddedItem.uri);
+        }
+      }
+    }
+
     this.cache.delete(uri);
   }
 


### PR DESCRIPTION
As per the 4.1.2 in the HAL spec, an embedded item MAY be a full or partial version of a resource. So if the embedded uri is already in the cache, make sure we "own" it before replacing it.

Found this bug, when I couldn't figure out why our account view only had partial data.
And that was because we have the account as a partial embedded item, on some resources.