### PR TITLE
Use HalState as a fallback for other JSON formats.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -158,7 +158,7 @@ export default class Client {
     } else if (contentType.startsWith('text/')) {
       // Default to TextState for any format starting with text/
       state = await textStateFactory(uri, response);
-    } else if (contentType.match(/^application\/[A-Za-z-\.]+\+json/)) {
+    } else if (contentType.match(/^application\/[A-Za-z-.]+\+json/)) {
       // Default to HalState for any format containing a pattern like application/*+json
       state = await halStateFactory(uri, response);
     } else {

--- a/src/client.ts
+++ b/src/client.ts
@@ -156,7 +156,11 @@ export default class Client {
     if (contentType in this.contentTypeMap) {
       state = await this.contentTypeMap[contentType][0](uri, response);
     } else if (contentType.startsWith('text/')) {
+      // Default to TextState for any format starting with text/
       state = await textStateFactory(uri, response);
+    } else if (contentType.match(/^application\/[A-Za-z-\.]+\+json/)) {
+      // Default to HalState for any format containing a pattern like application/*+json
+      state = await halStateFactory(uri, response);
     } else {
       state = await binaryStateFactory(uri, response);
     }


### PR DESCRIPTION
If the mimetype followed the pattern application/anything+json, we'll
just default to HalState. Might make this configurable later, but it's a
reasonable default for now.