### PR TITLE
Add HAL FORMS to accepted HAL mime types

### DIFF
--- a/src/representor/helper.ts
+++ b/src/representor/helper.ts
@@ -16,34 +16,39 @@ export default class RepresentorHelper {
 
     const defaultTypes: ContentType[] = [
       {
-        mime: 'application/hal+json',
+        mime: 'application/prs.hal-forms+json',
         representor: 'hal',
         q: '1.0',
       },
       {
+        mime: 'application/hal+json',
+        representor: 'hal',
+        q: '0.9',
+      },
+      {
         mime: 'application/vnd.api+json',
         representor: 'jsonapi',
-        q: '0.9',
+        q: '0.8',
       },
       {
         mime: 'application/vnd.siren+json',
         representor: 'siren',
-        q: '0.9',
+        q: '0.8',
       },
       {
         mime: 'application/vnd.collection+json',
         representor: 'collection-json',
-        q: '0.9',
+        q: '0.8',
       },
       {
         mime: 'application/json',
         representor: 'hal',
-        q: '0.8',
+        q: '0.7',
       },
       {
         mime: 'text/html',
         representor: 'html',
-        q: '0.7',
+        q: '0.6',
       }
 
     ];

--- a/test/integration/get.ts
+++ b/test/integration/get.ts
@@ -27,12 +27,13 @@ describe('Issuing a GET request', async () => {
     expect(result['user-agent']).to.match(/^Ketting\//);
 
     const mediaTypes = [
-      'application/hal+json;q=1.0',
-      'application/vnd.api+json;q=0.9',
-      'application/vnd.siren+json;q=0.9',
-      'application/vnd.collection+json;q=0.9',
-      'application/json;q=0.8',
-      'text/html;q=0.7',
+      'application/prs.hal-forms+json;q=1.0',
+      'application/hal+json;q=0.9',
+      'application/vnd.api+json;q=0.8',
+      'application/vnd.siren+json;q=0.8',
+      'application/vnd.collection+json;q=0.8',
+      'application/json;q=0.7',
+      'text/html;q=0.6',
     ];
 
     expect(result.accept).to.eql(mediaTypes.join(', '));

--- a/test/unit/representor/helper.ts
+++ b/test/unit/representor/helper.ts
@@ -27,6 +27,14 @@ describe('Representor Helper', () => {
 
     });
 
+    it('should return a Hal representor when requested', () => {
+
+      const helper = new Helper([]);
+      const representor = helper.create('/foo', 'application/prs.hal-forms+json', null, new Map());
+      expect(representor).to.be.instanceof(Hal);
+
+    });
+
     it('should return a Siren representor when requested', () => {
 
       const helper = new Helper([]);


### PR DESCRIPTION
Until HAL Forms is fully implemented in Ketting, this change adds its mime type to HAL representor.
This should not cause any trouble since HAL Forms is backward compatible with HAL.

Please note that adding a custom content type via Ketting options is not enough since we can't give it a `q` value higher than the value `1` assigned to the default `application/hal+json` content type:

```typescript
new Ketting('...', contentTypes: [{
                mime: 'application/prs.hal-forms+json',
                representor: 'hal',
                q: '1.0'
            }]);
```

```typescript
const defaultTypes: ContentType[] = [
      {
        mime: 'application/hal+json',
        representor: 'hal',
        q: '1.0',
      },
     // ....
    ];
```