### PR TITLE
Action system rewrite.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,6 +33,7 @@
           }
       ],
       "semi": ["error", "always"],
+      "no-trailing-spaces": "error",
       "no-unused-vars": ["error",
           {
             "args": "none",
@@ -45,7 +46,6 @@
           "ts-expect-error": "allow-with-description"
         }
       ],
-      "@typescript-eslint/no-explicit-any" : 0,
-      "@typescript-eslint/no-this-alias": 0
+      "@typescript-eslint/no-explicit-any" : 0
   }
 }

--- a/src/field.ts
+++ b/src/field.ts
@@ -68,4 +68,4 @@ export type Week = BaseField<'week', string>
 export type Field = Checkbox | Color | Date | DateTime | DateTimeLocal | Email
 // eslint-disable-next-line
   | File | Hidden | Number | Month | Password | Radio | Range | Search | Tel
-  | Text | Time | Url | Week; 
+  | Text | Time | Url | Week;

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -369,7 +369,7 @@ export declare interface Resource<T = any> {
    * and when updateCache() was used.
    */
   on(event: 'update', listener: (state: State) => void) : this
-  
+
   /**
    * Subscribe to the 'stale' event.
    *

--- a/src/state/base-state.ts
+++ b/src/state/base-state.ts
@@ -1,49 +1,31 @@
 import { State } from './interface';
 import { Links } from '../link';
 import Client from '../client';
-import { Action, ActionNotFound } from '../action';
+import { Action, ActionNotFound, ActionInfo, SimpleAction } from '../action';
 
+/**
+ * The Base State provides a convenient way to implement a new State type.
+ */
 export abstract class BaseState<T> implements State<T> {
 
   /**
-   * The URI associated with this state
+   * Timestamp of when the State was first generated
    */
-  uri: string;
-
-  /**
-   * Represents the body of the HTTP response.
-   *
-   * In the case of a JSON response, this will be deserialized
-   */
-  data: T
-
-  /**
-   * The full list of HTTP headers that were sent with the response.
-   */
-  headers: Headers;
-
-  /**
-   * All links associated with the resource.
-   */
-  links: Links;
+  timestamp: number;
 
   /**
    * Reference to main client that created this state
    */
   client!: Client;
 
-  /**
-   * Embedded resoureces
-   */
-  protected embedded: State[];
+  constructor(
+    public uri: string,
+    public data: T,
+    public headers: Headers,
+    public links: Links,
+    protected embedded: State[] = [],
+    protected actionInfo: ActionInfo[] = []) {
 
-  constructor(uri: string, data: T, headers: Headers, links: Links, embedded?: State[]) {
-
-    this.uri = uri;
-    this.data = data;
-    this.headers = headers;
-    this.links = links;
-    this.embedded = embedded || [];
     this.timestamp = Date.now();
 
   }
@@ -79,10 +61,22 @@ export abstract class BaseState<T> implements State<T> {
   /**
    * Return an action by name.
    *
-   * If the format provides a default action, the name may be omitted.
+   * If no name is given, the first action is returned. This is useful for
+   * formats that only supply 1 action, and no name.
    */
   action<TFormData = any>(name?: string): Action<TFormData> {
 
+    if (!this.actionInfo.length) {
+      throw new ActionNotFound('This State does not define any actions');
+    }
+    if (name === undefined) {
+      return new SimpleAction(this.client, this.actionInfo[0]);
+    }
+    for(const action of this.actionInfo) {
+      if (action.name === name) {
+        return new SimpleAction(this.client, this.actionInfo[0]);
+      }
+    }
     throw new ActionNotFound('This State defines no action');
 
   }
@@ -91,8 +85,8 @@ export abstract class BaseState<T> implements State<T> {
    * Returns all actions
    */
   actions(): Action[] {
-  
-    return [];
+
+    return this.actionInfo.map(action => new SimpleAction(this.client, action));
 
   }
 
@@ -119,11 +113,6 @@ export abstract class BaseState<T> implements State<T> {
     return this.embedded;
 
   }
-
-  /**
-   * Timestamp of when the State was first generated
-   */
-  timestamp: number;
 
   abstract clone(): State<T>;
 

--- a/src/state/base-state.ts
+++ b/src/state/base-state.ts
@@ -91,6 +91,23 @@ export abstract class BaseState<T> implements State<T> {
   }
 
   /**
+   * Checks if the specified action exists.
+   *
+   * If no name is given, checks if _any_ action exists.
+   */
+  hasAction(name?: string): boolean {
+
+    if (name===undefined) return this.actionInfo.length>0;
+    for(const action of this.actionInfo) {
+      if (name === action.name) {
+        return true;
+      }
+    }
+    return false;
+
+  }
+
+  /**
    * Returns a serialization of the state that can be used in a HTTP
    * response.
    *

--- a/src/state/interface.ts
+++ b/src/state/interface.ts
@@ -41,7 +41,7 @@ export interface State<T = any> {
   /**
    * Returns all actions
    */
-  actions(): Action[]; 
+  actions(): Action[];
 
   /**
    * Returns a serialization of the state that can be used in a HTTP

--- a/src/state/interface.ts
+++ b/src/state/interface.ts
@@ -44,6 +44,13 @@ export interface State<T = any> {
   actions(): Action[];
 
   /**
+   * Checks if the specified action exists.
+   *
+   * If no name is given, checks if _any_ action exists.
+   */
+  hasAction(name?: string): boolean;
+
+  /**
    * Returns a serialization of the state that can be used in a HTTP
    * response.
    *

--- a/src/state/siren.ts
+++ b/src/state/siren.ts
@@ -42,7 +42,7 @@ export class SirenState<T> extends BaseState<T> {
 /**
  * Turns a HTTP response into a SirenState
  */
-export const factory = async (uri: string, response: Response): Promise<SirenState<SirenEntity<any>>> => {
+export const factory = async (uri: string, response: Response): Promise<SirenState<any>> => {
 
   const body:SirenEntity<any> = await response.json();
 
@@ -51,7 +51,7 @@ export const factory = async (uri: string, response: Response): Promise<SirenSta
 
   return new SirenState(
     uri,
-    body,
+    body.properties,
     response.headers,
     links,
     parseSirenEmbedded(uri, body, response.headers),
@@ -226,7 +226,7 @@ function parseSirenSubEntityAsEmbedded(contextUri: string, subEntity: SirenSubEn
 
   return new SirenState(
     subEntityUrl,
-    subEntity,
+    subEntity.properties,
     headers,
     new Links(selfHref, parseSirenLinks(selfHref, subEntity)),
 

--- a/src/state/siren.ts
+++ b/src/state/siren.ts
@@ -39,11 +39,10 @@ export class SirenState<T> extends BaseState<T> {
 }
 
 
-
 /**
  * Turns a HTTP response into a SirenState
  */
-export const factory = async (uri: string, response: Response): Promise<SirenState<any>> => {
+export const factory = async (uri: string, response: Response): Promise<SirenState<SirenEntity<any>>> => {
 
   const body:SirenEntity<any> = await response.json();
 
@@ -52,7 +51,7 @@ export const factory = async (uri: string, response: Response): Promise<SirenSta
 
   return new SirenState(
     uri,
-    body.properties,
+    body,
     response.headers,
     links,
     parseSirenEmbedded(uri, body, response.headers),

--- a/test/unit/follower.ts
+++ b/test/unit/follower.ts
@@ -224,7 +224,7 @@ function getFakeResource(uri?: string, type?: string): Resource<{ firstGet: bool
   // if a get() was issued previously. This will be used for
   // testing prefetch.
   let firstGet = true;
-  
+
   fakeResource.get = async(getOptions: any) => {
 
     fakeResource.lastGetOptions = getOptions;

--- a/test/unit/link.ts
+++ b/test/unit/link.ts
@@ -57,7 +57,7 @@ describe('Links object', () => {
 
   it('should return the correct value from "has()"', () => {
 
-    const links = new Links('http://base.example/', [ 
+    const links = new Links('http://base.example/', [
       {
         context: 'http://base.example',
         href: 'http://a.example',


### PR DESCRIPTION
It's greatly simplified but makes more assumptions about the structure
of an action.

Actions are now basically a simple serialization for a HTML form. The
supported formats all fit in this structure, but it's possible that in
the future this is no longer the case.

This makes it possible however to take an action object, and have all
the information available to render a full HTML form.

This is a BC break for actions, but given that actions were still
experimental, I think that's OK. The API behaves mostly the same.

This will be released eventually as 6.1.

@reda-alaoui what do you tihnk?