### PR TITLE
Add a getCache function.

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -47,7 +47,7 @@ export class Resource<T = any> extends EventEmitter {
    */
   get(getOptions?: GetRequestOptions): Promise<State<T>> {
 
-    const state = this.client.cache.get(this.uri);
+    const state = this.getCache();
     if (!state) {
       return this.refresh(getOptions);
     }
@@ -301,6 +301,16 @@ export class Resource<T = any> extends EventEmitter {
   clearCache(): void {
 
     this.client.cache.delete(this.uri);
+
+  }
+
+  /**
+   * Retrieves the current cached resource state, and return `null` if it's
+   * not available.
+   */
+  getCache(): State<T>|null {
+
+    return this.client.cache.get(this.uri);
 
   }
 


### PR DESCRIPTION
This function gives you the current cached state of the resource, and
null if none was available.

The biggest benefit over .get is that it's not async, which will help
with inital stale-while-revalidate operations in react.