### PR TITLE
Templated links don't work if no template variables are supplied.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+6.1.4 (2020-11-30)
+------------------
+
+* #302: Templated links without template data don't work.
+
+
 6.1.3 (2020-11-19)
 ------------------
 

--- a/src/follow-promise.ts
+++ b/src/follow-promise.ts
@@ -173,8 +173,8 @@ export class FollowPromiseOne<T = any> extends FollowPromise<Resource<T>> {
     if (!link) throw new LinkNotFound(`Link with rel ${this.rel} on ${state.uri} not found`);
     let href;
 
-    if (link.templated && this.variables) {
-      href = expand(link, this.variables);
+    if (link.templated) {
+      href = expand(link, this.variables || {});
     } else {
       href = resolve(link);
     }

--- a/test/integration/follow-hal-template.ts
+++ b/test/integration/follow-hal-template.ts
@@ -23,4 +23,12 @@ describe('Following a templated link', async () => {
 
   });
 
+  it('should work even if no variables are specified', async () => {
+
+    hal2 = await ketting.follow('next').follow('prev').follow('templated');
+    expect(hal2).to.be.an.instanceof(Resource);
+    expect(hal2.uri).to.eql('http://localhost:3000/templated.json');
+
+  });
+
 });


### PR DESCRIPTION
Fixes #302