### PR TITLE
Update to new fetch-mw-oauth2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,9 +2323,9 @@
       }
     },
     "fetch-mw-oauth2": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/fetch-mw-oauth2/-/fetch-mw-oauth2-0.6.1.tgz",
-      "integrity": "sha512-ADcE+tIKs8/2QXCq4VCSt76F/vB+arsuQX0UCdWLNuk9vameHLNZuNr+WUuFVHVUlULndxTy10LgVWRIjO6NBg=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/fetch-mw-oauth2/-/fetch-mw-oauth2-0.7.0.tgz",
+      "integrity": "sha512-tN9uuCXx/FYDlHGukXcVhOvZzouawJZUJ4ni7bx3ayTcxcPaCyENIRmChNgzVRjLK6mYTC/8DfWPXC6OjCdpsQ=="
     },
     "file-entry-cache": {
       "version": "5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2323,9 +2323,9 @@
       }
     },
     "fetch-mw-oauth2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/fetch-mw-oauth2/-/fetch-mw-oauth2-0.7.0.tgz",
-      "integrity": "sha512-tN9uuCXx/FYDlHGukXcVhOvZzouawJZUJ4ni7bx3ayTcxcPaCyENIRmChNgzVRjLK6mYTC/8DfWPXC6OjCdpsQ=="
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/fetch-mw-oauth2/-/fetch-mw-oauth2-0.7.3.tgz",
+      "integrity": "sha512-mQ9s9Fb/U3C4t+agxAxYV1IhWD9bGM+50qmDq3VMiYThElzbBDem/R7SnSwx2FSIWN1EdS+Zb56LrX7NaSxrbQ=="
     },
     "file-entry-cache": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "types": "dist/index.d.ts",
   "dependencies": {
-    "fetch-mw-oauth2": "^0.7.0",
+    "fetch-mw-oauth2": "^0.7.3",
     "hal-types": "^1.2.1",
     "http-link-header": "^1.0.3",
     "node-fetch": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "types": "dist/index.d.ts",
   "dependencies": {
-    "fetch-mw-oauth2": "^0.6.1",
+    "fetch-mw-oauth2": "^0.7.0",
     "hal-types": "^1.2.1",
     "http-link-header": "^1.0.3",
     "node-fetch": "^2.6.1",

--- a/src/http/oauth2.ts
+++ b/src/http/oauth2.ts
@@ -1,9 +1,9 @@
 import { FetchMiddleware } from './fetcher';
-import { OAuth2Options, OAuth2 } from 'fetch-mw-oauth2';
+import { OAuth2Options, OAuth2, OAuth2Token } from 'fetch-mw-oauth2';
 
-export default (oauth2Options: OAuth2Options): FetchMiddleware => {
+export default (oauth2Options: OAuth2Options & Partial<OAuth2Token>, token?: OAuth2Token): FetchMiddleware => {
 
-  const oauth2 = new OAuth2(oauth2Options);
+  const oauth2 = new OAuth2(oauth2Options, token);
   return oauth2.fetchMw.bind(oauth2);
 
 };


### PR DESCRIPTION
* Ensure that only 1 refresh operation will happen in parallel. If there are multiple things triggering the refresh, all will wait for the first one to finish.
* Automatically schedule a refresh operation 1 minute before the access token expires, if the expiry time is known.