### PR TITLE
Add support for draft-dalal-deprecation-header.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,8 +5,8 @@ ChangeLog
 ------------------
 
 * Support for `draft-dalal-deprecation-header`. Ketting will now emit warnings
-  if a `Deprecated` header is detected, and will also provide information from
-  the `Sunset` header and include the uri of the `deprecated` link relation.
+  if a `Deprecation` header is detected, and will also provide information from
+  the `Sunset` header and include the uri of the `depreciation` link relation.
 
 
 6.2.0 (2020-12-01)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+6.3.0 (????-??-??)
+------------------
+
+* Support for `draft-dalal-deprecation-header`. Ketting will now emit warnings
+  if a `Deprecated` header is detected, and will also provide information from
+  the `Sunset` header and include the uri of the `deprecated` link relation.
+
+
 6.2.0 (2020-12-01)
 ------------------
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,6 +17,7 @@ import { FollowPromiseOne } from './follow-promise';
 import { StateCache, ForeverCache } from './cache';
 import cacheExpireMiddleware from './middlewares/cache-expire';
 import acceptMiddleware from './middlewares/accept-header';
+import warningMiddleware from './middlewares/warning';
 
 export default class Client {
 
@@ -70,6 +71,7 @@ export default class Client {
     this.fetcher = new Fetcher();
     this.fetcher.use(cacheExpireMiddleware(this));
     this.fetcher.use(acceptMiddleware(this));
+    this.fetcher.use(warningMiddleware());
     this.cache = new ForeverCache();
     this.resources = new Map();
   }

--- a/src/middlewares/warning.ts
+++ b/src/middlewares/warning.ts
@@ -1,0 +1,39 @@
+import { FetchMiddleware } from '../http/fetcher';
+import * as LinkHeader from 'http-link-header';
+import { resolve } from '../util/uri';
+
+/**
+ * This middleware will emit warnings based on HTTP responses.
+ *
+ * Currently it just inspects the 'Deprecation' HTTP header from
+ *   draft-dalal-deprecation-header
+ */
+export default function(): FetchMiddleware {
+
+  return async(request, next) => {
+
+    const response = await next(request);
+    const deprecation = response.headers.get('Deprecation');
+    if (deprecation) {
+      const sunset = response.headers.get('Sunset');
+      let msg = `[Ketting] The resource ${request.url} is deprecated.`;
+      if (sunset) {
+        msg += ' It will no longer respond ' + sunset;
+      }
+      // If the response had a Link: rel=invalidate header, we want to
+      // expire those too.
+      if (response.headers.has('Link')) {
+        for (const httpLink of LinkHeader.parse(response.headers.get('Link')!).rel('deprecation')) {
+          const uri = resolve(request.url, httpLink.uri);
+          msg += `See ${uri} for more information.`;
+        }
+      }
+
+      console.warn(msg);
+
+    }
+    return response;
+
+  };
+
+}

--- a/src/state/base-state.ts
+++ b/src/state/base-state.ts
@@ -43,8 +43,11 @@ export abstract class BaseState<T> implements State<T> {
     const contentHeaderNames = [
       'Content-Type',
       'Content-Language',
+      'Deprecation',
       'ETag',
       'Last-Modified',
+      'Sunset',
+      'Warning',
     ];
 
     const result: {[name: string]: string} = {};

--- a/test/unit/middleware/warning.ts
+++ b/test/unit/middleware/warning.ts
@@ -1,0 +1,77 @@
+import warningMiddleware from '../../../src/middlewares/warning';
+import { expect } from 'chai';
+
+const invoke = (response: Response) => {
+
+  const mw = warningMiddleware();
+  return mw(new Request('http://test.example'), () => Promise.resolve(response));
+
+};
+
+describe('Warning middleware', () => {
+
+  let oldWarning: any;
+  let lastMessage = '';
+
+  before(() => {
+
+    lastMessage = '';
+    oldWarning = console.warn;
+    console.warn = (msg: string) => {
+      lastMessage = msg;
+    };
+
+  });
+
+  it('Should normally not emit a warning', async () => {
+
+    await invoke(new Response());
+    expect(lastMessage).to.equal('');
+
+  });
+  it('Should emit a warning if a Deprecation header is returned', async () => {
+
+    await invoke(new Response(null, {
+      headers: {
+        Deprecation: 'true'
+      }
+    }));
+    expect(lastMessage).to.contain('deprecated');
+    expect(lastMessage).to.contain('http://test.example');
+
+  });
+  it('Should include sunset information in the warning if it was provided', async () => {
+
+    await invoke(new Response(null, {
+      headers: {
+        Deprecation: 'true',
+        Sunset: 'Wed, 11 Nov 2020 23:59:59 GMT'
+      }
+    }));
+    expect(lastMessage).to.contain('deprecated');
+    expect(lastMessage).to.contain('http://test.example');
+    expect(lastMessage).to.contain('Wed, 11 Nov 2020 23:59:59 GMT');
+
+  });
+  it('Should include a documentation link for the deprecation status if it was provided', async () => {
+
+    await invoke(new Response(null, {
+      headers: {
+        Deprecation: 'true',
+        Link: '</docs>; rel="deprecation"',
+      }
+    }));
+    expect(lastMessage).to.contain('deprecated');
+    expect(lastMessage).to.contain('http://test.example');
+    expect(lastMessage).to.contain('http://test.example/docs');
+
+  });
+
+
+  after(() => {
+
+    console.warn = oldWarning;
+
+  });
+
+});


### PR DESCRIPTION
Ketting will now emit warnings if it runs into a 'Deprecation' HTTP response header.