### PR TITLE
Using field titles in Siren

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+7.0.0-beta.2 (2021-??-??)
+-------------------------
+
+* Support for Siren 'title' on fields. This was an oversight.
+
+
 7.0.0-beta.1 (2021-01-25)
 -------------------------
 

--- a/src/state/siren.ts
+++ b/src/state/siren.ts
@@ -265,5 +265,9 @@ function sirenFieldToField(input: SirenField): Field {
   if (input.value) {
     result.value = input.value;
   }
+  if (input.title) {
+    result.label = input.title;
+  }
+
   return result;
 }


### PR DESCRIPTION
Something in the siren spec caused me to miss a couple of properties on fields in Siren. Got the whole set now i think