### PR TITLE
The uri of a HAL Forms action without target attribute should be the self link of the resource exposing it

### DIFF
--- a/src/state/hal.ts
+++ b/src/state/hal.ts
@@ -259,7 +259,7 @@ function parseHalForms(context: string, body: hal.HalResource): ActionInfo[] {
 
   return Object.entries(body._templates).map( ([key, hf]) => {
     return {
-      uri: resolve(context, hf.target || ''),
+      uri: resolve(context, hf.target || body._links?.self?.href || ''),
       name: key,
       title: hf.title,
       method: hf.method,

--- a/test/unit/state/hal-forms.ts
+++ b/test/unit/state/hal-forms.ts
@@ -36,6 +36,37 @@ describe('HAL forms', () => {
     expect(action).to.eql(expected);
 
   });
+  it('should parse an action without target', async () => {
+
+    const hal = await callFactory({
+      _links: {
+        self: {
+          href: '/foo/1'
+        }
+      },
+      _templates: {
+        default: {
+          method: 'POST',
+        }
+      }
+    });
+
+    const action:any = hal.action('default');
+    delete action.client;
+    delete action.submit;
+
+    const expected: CompareAction = {
+      uri: 'http://example/foo/1',
+      name: 'default',
+      title: undefined,
+      contentType: 'application/json',
+      method: 'POST',
+      fields: [],
+    };
+
+    expect(action).to.eql(expected);
+
+  });
   it('should parse a field', async () => {
 
     const hal = await callFactory({
@@ -123,6 +154,61 @@ describe('HAL forms', () => {
             },
           ]
         }
+      }
+    });
+    const embeddedAction: any = hal.getEmbedded()[0].action('default');
+    delete embeddedAction.client;
+    delete embeddedAction.submit;
+
+    const expected: CompareAction = {
+      uri: 'http://example/foo/1',
+      name: 'default',
+      title: undefined,
+      contentType: 'application/json',
+      method: 'PUT',
+      fields: [
+        {
+          type: 'text',
+          name: 'text',
+          required: false,
+          readOnly: false,
+          label: undefined,
+          pattern: undefined,
+          placeholder: undefined,
+          value: undefined,
+        }
+      ],
+    };
+
+    expect(embeddedAction).to.eql(expected);
+  });
+  it('should parse embedded action without target', async () => {
+    const hal = await callFactory({
+      _links: {
+        self: {
+          href: '/foo'
+        }
+      },
+      _embedded: {
+        content: [{
+          _links: {
+            self: {
+              href: '/foo/1',
+            }
+          },
+          _templates: {
+            default: {
+              method: 'PUT',
+              properties: [
+                {
+                  type: 'text',
+                  name: 'text',
+                },
+              ]
+            }
+          },
+          id: 1,
+        }]
       }
     });
     const embeddedAction: any = hal.getEmbedded()[0].action('default');


### PR DESCRIPTION
Currently, when receiving the following response:

```json
{
  "_links": {
    "self": {
      "href": "/foo"
    }
  },
  "_embedded": {
    "content": [
      {
        "_links": {
          "self": {
            "href": "/foo/1"
          }
        },
        "_templates": {
          "default": {
            "method": "PUT"
          }
        },
        "id": 1
      }
    ]
  }
}
```

Ketting produces an action with uri `/foo` instead of `/foo/1`