### PR TITLE
HAL: Relative URIs in embedded docs are now resolved with the self link.

### DIFF
--- a/src/state/hal.ts
+++ b/src/state/hal.ts
@@ -226,6 +226,9 @@ function parseHalEmbedded(client: Client, context: string, body: hal.HalResource
         // Skip any embedded without a self link.
         continue;
       }
+
+      const embeddedSelf = resolve(context, embeddedItem._links.self.href);
+
       // Remove _links and _embedded from body
       const {
         _embedded,
@@ -235,16 +238,16 @@ function parseHalEmbedded(client: Client, context: string, body: hal.HalResource
 
       result.push(new HalState({
         client,
-        uri: resolve(context, embeddedItem._links.self.href),
+        uri: embeddedSelf,
         data: newBody,
         headers: new Headers({
           'Content-Type': headers.get('Content-Type')!,
         }),
-        links: new Links(context, parseHalLinks(context, embeddedItem)),
+        links: new Links(embeddedSelf, parseHalLinks(context, embeddedItem)),
         // Parsing nested embedded items. Note that we assume that the base url is relative to
         // the outermost parent, not relative to the embedded item. HAL is not clear on this.
-        embedded: parseHalEmbedded(client, context, embeddedItem, headers),
-        actions: parseHalForms(context, embeddedItem)
+        embedded: parseHalEmbedded(client, embeddedSelf, embeddedItem, headers),
+        actions: parseHalForms(embeddedSelf, embeddedItem)
       }));
     }
   }

--- a/test/unit/state/hal-forms.ts
+++ b/test/unit/state/hal-forms.ts
@@ -55,6 +55,41 @@ describe('HAL forms', () => {
     expect(deleteAction).to.eql(expectedDeleteAction);
 
   });
+  it('should relate relative URIs of embedded HAL forms to the embedded resource\'s self uri', async () => {
+
+    const hal = await callFactory({
+      _links: {
+      },
+      _embedded: {
+        foo: {
+          _links: {
+            self: { href: '/foo/' },
+          },
+          _templates: {
+            default: {
+              target: 'bar',
+              method: 'POST',
+            },
+          }
+        }
+      }
+    });
+
+    const defaultAction:any = hal.getEmbedded()[0].action('default');
+    delete defaultAction.client;
+
+    const expectedDefaultAction: CompareAction = {
+      uri: 'http://example/foo/bar',
+      name: 'default',
+      title: undefined,
+      contentType: 'application/json',
+      method: 'POST',
+      fields: [],
+    };
+
+    expect(defaultAction).to.eql(expectedDefaultAction);
+
+  });
   it('should parse a field', async () => {
 
     const hal = await callFactory({

--- a/test/unit/state/hal-forms.ts
+++ b/test/unit/state/hal-forms.ts
@@ -90,6 +90,40 @@ describe('HAL forms', () => {
     expect(defaultAction).to.eql(expectedDefaultAction);
 
   });
+  it('should default to the resource\'s self uri if no target was given', async () => {
+
+    const hal = await callFactory({
+      _links: {
+      },
+      _embedded: {
+        foo: {
+          _links: {
+            self: { href: '/foo/' },
+          },
+          _templates: {
+            default: {
+              method: 'POST',
+            },
+          }
+        }
+      }
+    });
+
+    const defaultAction:any = hal.getEmbedded()[0].action('default');
+    delete defaultAction.client;
+
+    const expectedDefaultAction: CompareAction = {
+      uri: 'http://example/foo/',
+      name: 'default',
+      title: undefined,
+      contentType: 'application/json',
+      method: 'POST',
+      fields: [],
+    };
+
+    expect(defaultAction).to.eql(expectedDefaultAction);
+
+  });
   it('should parse a field', async () => {
 
     const hal = await callFactory({


### PR DESCRIPTION
This replaces #393.

It was pointed out by @reda-alaoui that if a HAL Form is embedded inside
an embedded document, the 'target' attribute (which is a URI) is
resolved with the URI of the main document, not the self link of an
embedded document.

I tried to find a source for what the correct behavior for _any_ link in
an embedded document HAL-Forms or HAL itself is, but there's no guidance.

Intuitively it feels that resources that are serialized are likely
serialized by the same process, whether they are stand-alone or
embedded, so if I had to pick a behavior, it makes more sense to me that
we use the embedded uri.

To my surprise and sadness, it looks like we've never done this for
HAL-Forms inside `_embedded`, but also not `_links` or nested
`_embedded` in `_embedded`.

This PR fixes this for all cases, but the question now is: "Is this a major
BC break?".

I partially feel no, because I feel that most people very likely don't
embed items from other absolute domains, and relative uris in resources
are very likely to at least always start with a `/`. I suspect that this
is the 99% case, and for those people this change is irrelevant.

But for the other 1%, this will break their clients and it means this small
change needs to be released as Ketting 8.