### PR TITLE
Don't crash when '_embedded' is set null.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "src/",
     "dist/",
     "browser/ketting.min.js",
-    "browser/ketting.min.js.map"
+    "browser/ketting.min.js.map",
+    "LICENSE"
   ],
   "types": "dist/index.d.ts",
   "dependencies": {

--- a/src/state/hal.ts
+++ b/src/state/hal.ts
@@ -204,7 +204,7 @@ function parseHalLink(context: string, rel: string, links: hal.HalLink[]): Link[
  */
 function parseHalEmbedded(client: Client, context: string, body: hal.HalResource, headers: Headers): HalState<any>[] {
 
-  if (body._embedded === undefined) {
+  if (body._embedded === undefined || !body._embedded) {
     return [];
   }
 

--- a/test/unit/state/hal.ts
+++ b/test/unit/state/hal.ts
@@ -240,6 +240,17 @@ describe('HAL state factory', () => {
     expect(hal.data).to.eql([1, 2, 3]);
 
   });
+  it('shouldnt die when _embedded is encoded as null', async () => {
+
+    // this is probably technically invalid HAL, but we want to be somewhat robust.
+
+    const hal = await callFactory({
+      _embedded: null
+    });
+
+    expect(hal.links.getAll()).to.eql([]);
+
+  });
 
 });
 


### PR DESCRIPTION
_embedded being null is probably an invalid HAL document, but this makes
the parser a bit more robust for errors.

Fixes #404