### PR TITLE
Emit a warning when an _embedded entry without a self link was found.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+7.2.1 (2021-??-??)
+------------------
+
+* #408: Emit a warning when an `_embedded` HAL item is missing a good `self`
+  link.
+
+
 7.2.0 (2021-08-04)
 -----------------
 

--- a/src/state/hal.ts
+++ b/src/state/hal.ts
@@ -222,8 +222,9 @@ function parseHalEmbedded(client: Client, context: string, body: hal.HalResource
     }
     for (const embeddedItem of embeddedList) {
 
-      if (embeddedItem._links === undefined || embeddedItem._links.self === undefined || Array.isArray(embeddedItem._links.self)) {
-        // Skip any embedded without a self link.
+      if (embeddedItem._links?.self?.href === undefined) {
+        // eslint-disable-next-line no-console
+        console.warn('An item in _embedded was ignored. Each item must have a single "self" link');
         continue;
       }
 


### PR DESCRIPTION
Fixes #408