### PR TITLE
Don't error when 204 is returned with a content-type.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -151,25 +151,21 @@ export default class Client {
 
     const contentType = parseContentType(response.headers.get('Content-Type')!);
 
-    let state: State;
-
-    if (!contentType) {
+    if (!contentType || response.status === 204) {
       return binaryStateFactory(this, uri, response);
     }
 
     if (contentType in this.contentTypeMap) {
-      state = await this.contentTypeMap[contentType][0](this, uri, response);
+      return this.contentTypeMap[contentType][0](this, uri, response);
     } else if (contentType.startsWith('text/')) {
       // Default to TextState for any format starting with text/
-      state = await textStateFactory(this, uri, response);
+      return textStateFactory(this, uri, response);
     } else if (contentType.match(/^application\/[A-Za-z-.]+\+json/)) {
       // Default to HalState for any format containing a pattern like application/*+json
-      state = await halStateFactory(this, uri, response);
+      return halStateFactory(this, uri, response);
     } else {
-      state = await binaryStateFactory(this, uri, response);
+      return binaryStateFactory(this, uri, response);
     }
-
-    return state;
 
   }
 

--- a/test/unit/client.ts
+++ b/test/unit/client.ts
@@ -186,4 +186,18 @@ describe('Client', () => {
 
   });
 
+  describe('getStateForResponse', () => {
+
+    it('should handle 204 responses', async () => {
+
+      const client = new Client('https://example.org');
+      const resp = new Response(null, {status: 204});
+      const state = await client.getStateForResponse('/foo', resp);
+      expect(state.uri).to.equal('/foo');
+
+    });
+
+
+  });
+
 });


### PR DESCRIPTION
Fixes #414.

Many servers will return a `Content-Type` for 204 responses, even though
this is probably incorrect, but at least meaningless.

This fix ensures that we're not attempting to parse the response body
if a 204 is returned.