### PR TITLE
Increase 'max listeners'.

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -37,6 +37,7 @@ export class Resource<T = any> extends EventEmitter {
     this.client = client;
     this.uri = uri;
     this.activeRefresh = null;
+    this.setMaxListeners(500);
 
   }
 


### PR DESCRIPTION
When Ketting is used in the frontend, we want to encourage it being used as a store for central state. If a piece of data is used in different places, this will usually result in events being registered.

The default of 10 is quite low, and standard applications often start emitting tons of annoying warnings for 'max listeners'. This is annoying and creates distrust. Having a lot of listeners on a single EventEmitter _can_ be indicative of a memory leak, but having lots of listeners itself is not cause for concern.

This PR increases it to 500 for the Resource object. This is plenty of room.