### PR TITLE
Support inv-by cache dependencies from HAL bodies

### DIFF
--- a/src/middlewares/cache.ts
+++ b/src/middlewares/cache.ts
@@ -30,21 +30,6 @@ export default function(client: Client): FetchMiddleware {
 
     const response = await next(request);
 
-    // If the response had a Link: rel=inv-by header, it means that when the
-    // target uri's cache expires, the uri of this resource should also
-    // expire.
-    if (response.headers.has('Link')) {
-      for (const httpLink of LinkHeader.parse(response.headers.get('Link')!).rel('inv-by')) {
-        const uri = resolve(request.url, httpLink.uri);
-        if (client.cacheDependencies.has(uri)) {
-          client.cacheDependencies.get(uri)!.add(request.url);
-        } else {
-          client.cacheDependencies.set(uri, new Set([request.url]));
-        }
-      }
-    }
-
-
     if (isSafeMethod(request.method)) {
       return response;
     }


### PR DESCRIPTION
The `inv-by` link is an incredibly useful tool to automatically let resources expire when other resources expire.

In Ketting it was only possible to communicate this if those links appeared in HTTP Link headers.

This PR ensures that the inv-by link is now also supported in:

* HAL _links
* HAL _links inside HAL _embedded
* Any other format that supports links really