### PR TITLE
getEmbedded() should be discouraged

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,9 @@
         "typescript": "^4.2.3",
         "webpack": "^5.24.3",
         "webpack-cli": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/state/interface.ts
+++ b/src/state/interface.ts
@@ -88,13 +88,16 @@ export type State<T = any> = {
   contentHeaders(): Headers;
 
   /**
-   * Certain formats can embed other resources, identified by their
-   * own URI.
+   * Some formats support embedding resources inside other resources.
    *
-   * When a format has embedded resources, we will use these to warm
-   * the cache.
+   * Please note: generally you should always use the .follow() and
+   * .followAll() functions to get access to linked embedded resources.
    *
-   * This method returns every embedded resource.
+   * There's several operations that change the State in the Ketting Cache,
+   * and usually this erases any associated embedded resources.
+   *
+   * .follow() and .followAll() will return the embedded resources, and also
+   * keeps their respective states fresh when changes are made.
    */
   getEmbedded(): State[];
 


### PR DESCRIPTION
Maybe there's an even better solution out there, but for now we should steer people away from getEmbedded a bit more.

See: #428 #407 #275 #273