### PR TITLE
Allow Link objects to be passed to the 'go' function.

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,7 @@ import {
 } from './state';
 import { parseContentType } from './http/util';
 import { resolve } from './util/uri';
-import { LinkVariables } from './link';
+import { Link, LinkVariables } from './link';
 import { FollowPromiseOne } from './follow-promise';
 import { StateCache, ForeverCache } from './cache';
 import cacheExpireMiddleware from './middlewares/cache';
@@ -105,13 +105,15 @@ export default class Client {
    * @example
    * const res = ketting.go(); // bookmark
    */
-  go<TResource = any>(uri?: string): Resource<TResource> {
+  go<TResource = any>(uri?: string|Link): Resource<TResource> {
 
     let absoluteUri;
-    if (uri !== undefined) {
+    if (uri === undefined) {
+      absoluteUri = this.bookmarkUri;
+    } else if (typeof uri === 'string') {
       absoluteUri = resolve(this.bookmarkUri, uri);
     } else {
-      absoluteUri = this.bookmarkUri;
+      absoluteUri = resolve(uri);
     }
     if (!this.resources.has(absoluteUri)) {
       const resource = new Resource(this, absoluteUri);

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -261,10 +261,13 @@ export class Resource<T = any> extends EventEmitter {
    *
    * This function doesn't do any HTTP requests.
    */
-  go<TGoResource = any>(uri: string): Resource<TGoResource> {
+  go<TGoResource = any>(uri: string|Link): Resource<TGoResource> {
 
-    uri = resolve(this.uri, uri);
-    return this.client.go(uri);
+    if (typeof uri === 'string') {
+      return this.client.go(resolve(this.uri, uri));
+    } else {
+      return this.client.go(uri);
+    }
 
   }
 


### PR DESCRIPTION
This makes following links a tad easier. For example:

```typescript
client.go(
  resourceState.links.get('collection')
);
```

Instead of:

```typescript
const link = resourceState.links.get('collection');
client.go(
  resolve(link.context, link.href)
);
```

Fixes #328 