### PR TITLE
Adding a `rel='deletes'` link

### DIFF
--- a/src/middlewares/cache.ts
+++ b/src/middlewares/cache.ts
@@ -52,9 +52,16 @@ export default function(client: Client): FetchMiddleware {
     // If the response had a Link: rel=invalidate header, we want to
     // expire those too.
     if (response.headers.has('Link')) {
-      for (const httpLink of LinkHeader.parse(response.headers.get('Link')!).rel('invalidates')) {
+      const httpLinks = LinkHeader.parse(response.headers.get('Link')!);
+
+      for (const httpLink of httpLinks.rel('invalidates')) {
         const uri = resolve(request.url, httpLink.uri);
         stale.push(uri);
+      }
+
+      for (const httpLink of httpLinks.rel('deletes')) {
+        const uri = resolve(request.url, httpLink.uri);
+        deleted.push(uri);
       }
     }
 

--- a/test/unit/middleware/cache.ts
+++ b/test/unit/middleware/cache.ts
@@ -1,0 +1,74 @@
+/* eslint-disable no-console */
+import { expect } from 'chai';
+
+import { BaseState, Client, ForeverCache, Links, Resource } from '../../../src';
+
+import cacheMiddleware from '../../../src/middlewares/cache';
+
+const invoke = (response: Response, client: Client) => {
+  const mw = cacheMiddleware(client);
+
+  return mw(new Request('http://test.example', {
+    method: 'POST',
+  }), () => Promise.resolve(response));
+};
+
+describe('Cache middleware', () => {
+  const client = new Client('http://test.example');
+  client.cache = new ForeverCache();
+
+  const resource = new Resource(client, 'http://example/foo');
+  const resourceEvents: string[] = [];
+
+  beforeEach(() => {
+    const state = new BaseState({
+      client,
+      uri: 'http://example/foo',
+      data: 'hi',
+      headers: new Headers(),
+      links: new Links('http://example/foo')
+    });
+
+    client.cache.store(state);
+
+    client.resources.set('http://example/foo', resource);
+
+    resource.emit = event => {
+      resourceEvents.push(event);
+
+      return true;
+    };
+  });
+
+  it('Should normally not emit delete entries from cache', async () => {
+    await invoke(new Response(), client);
+
+    expect(client.cache.has('http://example/foo')).to.equal(true);
+    expect(resourceEvents).to.not.contain('delete');
+  });
+
+  it('Should normally not emit delete event when have rel="invalidates" link', async () => {
+    const response = new Response(null, {
+      headers: {
+        Link: '<http://example/foo>; rel="invalidates"',
+      }
+    });
+
+    await invoke(response, client);
+
+    expect(resourceEvents).to.not.contain('delete');
+  });
+
+  it('Should emit delete entries from cache when have rel="deletes" link', async () => {
+    const response = new Response(null, {
+      headers: {
+        Link: '<http://example/foo>; rel="deletes"',
+      }
+    });
+
+    await invoke(response, client);
+
+    expect(client.cache.has('http://example/foo')).to.equal(false);
+    expect(resourceEvents).to.contain('delete');
+  });
+});


### PR DESCRIPTION
In some case, a POST or PUT call can delete some resources. 

The problem is, when a HTTP method returns a Link header that contains a
`rel="invalidates"`, then this can signal a client that the cache for the
collection is no longer fresh, but send event to refresh a deleted resources. (cf. #152)

My solution is adding new rel option called `deletes`. 

```
Link: </foo>; rel="deletes"
```

When a HTTP method returns a Link header that contains a
`rel="deletes"`, then it means that the HTTP request that was recently
performed has caused other deleted resources.