### PR TITLE
Restored parsing of minLength and maxLength for use in input and textarea fields.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "fetch-mw-oauth2": "^1.0.0",
-        "hal-types": "^1.7.4",
+        "hal-types": "^1.7.7",
         "http-link-header": "^1.0.3",
         "querystring-browser": "^1.0.4",
         "sax": "^1.2.4",
@@ -2818,9 +2818,9 @@
       }
     },
     "node_modules/hal-types": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/hal-types/-/hal-types-1.7.4.tgz",
-      "integrity": "sha512-MXIm5IbUZJ+gr6hhXvf0FH59eNDgSW4UbDip4Pv/9sa6gHlVQUbO+tYl0CsD26jN5lw3TgIbcFoi4frcS4jPdg=="
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/hal-types/-/hal-types-1.7.7.tgz",
+      "integrity": "sha512-o1MG92pVxrehRk2tH3rJnpMad7Hg78tuyDN7oSlQ5VNczJrjL/AGIdm/biwi0gUOxZdFuN1mdKHklP0IBguIOA=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -7954,9 +7954,9 @@
       "dev": true
     },
     "hal-types": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/hal-types/-/hal-types-1.7.4.tgz",
-      "integrity": "sha512-MXIm5IbUZJ+gr6hhXvf0FH59eNDgSW4UbDip4Pv/9sa6gHlVQUbO+tYl0CsD26jN5lw3TgIbcFoi4frcS4jPdg=="
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/hal-types/-/hal-types-1.7.7.tgz",
+      "integrity": "sha512-o1MG92pVxrehRk2tH3rJnpMad7Hg78tuyDN7oSlQ5VNczJrjL/AGIdm/biwi0gUOxZdFuN1mdKHklP0IBguIOA=="
     },
     "has": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "types": "dist/index.d.ts",
   "dependencies": {
     "fetch-mw-oauth2": "^1.0.0",
-    "hal-types": "^1.7.4",
+    "hal-types": "^1.7.7",
     "http-link-header": "^1.0.3",
     "querystring-browser": "^1.0.4",
     "sax": "^1.2.4",

--- a/src/field.ts
+++ b/src/field.ts
@@ -82,6 +82,8 @@ interface BooleanField extends BaseField<boolean> {
  */
 interface BasicStringField extends BaseField<string> {
   type: 'color' | 'email' | 'password' | 'search' | 'tel' | 'url';
+  minLength?: number;
+  maxLength?: number;
 }
 
 interface RangeStringField extends RangeField<string> {

--- a/src/field.ts
+++ b/src/field.ts
@@ -94,6 +94,8 @@ interface DateTimeField extends RangeField<Date> {
 
 interface HiddenField extends BaseField<string | number | null | boolean> {
   type: 'hidden';
+  minLength?: number;
+  maxLength?: number;
 }
 
 interface FileField extends BaseField<never> {

--- a/src/state/hal.ts
+++ b/src/state/hal.ts
@@ -335,6 +335,8 @@ function parseHalField(halField: hal.HalFormsProperty): Field {
           pattern: halField.regex ? new RegExp(halField.regex) : undefined,
           label: halField.prompt,
           placeholder: halField.placeHolder,
+          minLength: halField.minLength,
+          maxLength: halField.maxLength,
         };
       }
     case 'hidden' :
@@ -346,6 +348,8 @@ function parseHalField(halField: hal.HalFormsProperty): Field {
         value: halField.value,
         label: halField.prompt,
         placeholder: halField.placeHolder,
+        minLength: halField.minLength,
+        maxLength: halField.maxLength,
       };
     case 'textarea' :
       return {
@@ -358,6 +362,8 @@ function parseHalField(halField: hal.HalFormsProperty): Field {
         placeholder: halField.placeHolder,
         cols: halField.cols,
         rows: halField.rows,
+        minLength: halField.minLength,
+        maxLength: halField.maxLength,
       };
     case 'password' :
       return {
@@ -367,6 +373,8 @@ function parseHalField(halField: hal.HalFormsProperty): Field {
         readOnly: halField.readOnly || false,
         label: halField.prompt,
         placeholder: halField.placeHolder,
+        minLength: halField.minLength,
+        maxLength: halField.maxLength,
       };
     case 'date' :
     case 'month' :

--- a/test/unit/state/hal-forms.ts
+++ b/test/unit/state/hal-forms.ts
@@ -163,6 +163,8 @@ describe('HAL forms', () => {
           label: undefined,
           pattern: undefined,
           placeholder: undefined,
+          maxLength: undefined,
+          minLength: undefined,
           value: undefined,
         }
       ],
@@ -232,6 +234,8 @@ describe('HAL forms', () => {
           label: undefined,
           pattern: undefined,
           placeholder: undefined,
+          maxLength: undefined,
+          minLength: undefined,
           value: undefined,
         }
       ],


### PR DESCRIPTION
I've restored parsing of minLength and maxLength for use in form validation of textarea and the input types that make sense.