### PR TITLE
Upgrade from fetch-mw-oauth2 to @badgateway/oauth2-client

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,6 +36,7 @@
           }
       ],
       "semi": ["error", "always"],
+      "no-console": ["error", { "allow": ["warn", "error", "info", "debug"] }],
       "no-trailing-spaces": "error",
       "eol-last": "error",
       "@typescript-eslint/ban-ts-comment": ["error",
@@ -61,7 +62,6 @@
       }],
       "@typescript-eslint/prefer-for-of": ["error"],
       "@typescript-eslint/prefer-optional-chain": ["error"],
-      "@typescript-eslint/prefer-ts-expect-error": ["error"],
-      "no-console": ["error"]
+      "@typescript-eslint/prefer-ts-expect-error": ["error"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.5.1",
       "license": "MIT",
       "dependencies": {
-        "fetch-mw-oauth2": "^1.0.0",
+        "@badgateway/oauth2-client": "^2.0.17",
         "hal-types": "^1.7.7",
         "http-link-header": "^1.0.3",
         "querystring-browser": "^1.0.4",
@@ -457,6 +457,14 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@badgateway/oauth2-client": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@badgateway/oauth2-client/-/oauth2-client-2.0.17.tgz",
+      "integrity": "sha512-w3KIE0wCF2heYZyD3cf0IhbzCU0OtInwfyVdaisRSyo64UDpnFkFxK6GwstUi9oE8TvDuGmfKeUdDwDdLwvVZg==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2518,11 +2526,6 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/fetch-mw-oauth2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fetch-mw-oauth2/-/fetch-mw-oauth2-1.0.2.tgz",
-      "integrity": "sha512-q++P/1vekmDR5kIOCyiTeovcPeZPznlC2C116Zs68AP/S1bTlmXOtfZBeG0rkqe/kMSQCkgyZI6AsOMtgsmLxA=="
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
@@ -6027,6 +6030,11 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@badgateway/oauth2-client": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@badgateway/oauth2-client/-/oauth2-client-2.0.17.tgz",
+      "integrity": "sha512-w3KIE0wCF2heYZyD3cf0IhbzCU0OtInwfyVdaisRSyo64UDpnFkFxK6GwstUi9oE8TvDuGmfKeUdDwDdLwvVZg=="
+    },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -7646,11 +7654,6 @@
       "requires": {
         "reusify": "^1.0.4"
       }
-    },
-    "fetch-mw-oauth2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fetch-mw-oauth2/-/fetch-mw-oauth2-1.0.2.tgz",
-      "integrity": "sha512-q++P/1vekmDR5kIOCyiTeovcPeZPznlC2C116Zs68AP/S1bTlmXOtfZBeG0rkqe/kMSQCkgyZI6AsOMtgsmLxA=="
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "types": "dist/index.d.ts",
   "dependencies": {
-    "fetch-mw-oauth2": "^1.0.0",
+    "@badgateway/oauth2-client": "^2.0.17",
     "hal-types": "^1.7.7",
     "http-link-header": "^1.0.3",
     "querystring-browser": "^1.0.4",

--- a/src/http/oauth2.ts
+++ b/src/http/oauth2.ts
@@ -1,9 +1,262 @@
 import { FetchMiddleware } from './fetcher';
-import { OAuth2Options, OAuth2, OAuth2Token } from 'fetch-mw-oauth2';
+import { OAuth2Client, OAuth2Fetch } from '@badgateway/oauth2-client';
 
-export default (oauth2Options: OAuth2Options & Partial<OAuth2Token>, token?: OAuth2Token): FetchMiddleware => {
+function oauth2mw(oauth2Options: OAuth2Options, token?: OAuth2Token): FetchMiddleware {
 
-  const oauth2 = new OAuth2(oauth2Options, token);
-  return oauth2.fetchMw.bind(oauth2);
+  console.warn('The OAuth2 middleware in Ketting is deprecated, and will be removed in the next major version of Ketting. You should upgrade to the OAuth2Fetch from the @badgateway/oauth2-client project');
 
+  // This code converts the old 'fetch-mw-oauth2' options format to the new
+  // oauth2 client we use now, which is why it's a bit clunky.
+  const newOptions: ConstructorParameters<typeof OAuth2Client>[0] = {
+    clientId: oauth2Options.clientId,
+    clientSecret: 'clientSecret' in oauth2Options ? oauth2Options.clientSecret : undefined,
+    tokenEndpoint: oauth2Options.tokenEndpoint,
+  };
+
+
+  const oauth2Client = new OAuth2Client(newOptions);
+  const oauth2Fetch = new OAuth2Fetch({
+    client: oauth2Client,
+    getNewToken: async() => {
+
+      switch(oauth2Options.grantType) {
+        case 'password' :
+          return oauth2Client.password({
+            username: oauth2Options.userName,
+            password: oauth2Options.password,
+            scope: oauth2Options.scope,
+          });
+        case 'client_credentials' :
+          return oauth2Client.clientCredentials({
+            scope: oauth2Options.scope
+          });
+        case 'authorization_code' :
+          return oauth2Client.authorizationCode.getToken({
+            code: oauth2Options.code,
+            codeVerifier: oauth2Options.codeVerifier,
+            redirectUri: oauth2Options.redirectUri,
+          });
+        case undefined:
+          return null;
+      }
+
+    },
+
+    getStoredToken: (): OAuth2Token|null => {
+      return token ?? null;
+    },
+
+    storeToken: (token: OAuth2Token) => {
+      if (oauth2Options.onTokenUpdate) {
+        oauth2Options.onTokenUpdate(token);
+      }
+    },
+
+    onError: (err: Error) => {
+      if (oauth2Options.onAuthError) {
+        oauth2Options.onAuthError(err);
+      }
+    }
+  });
+
+
+
+  return oauth2Fetch.mw();
+}
+
+
+export default oauth2mw;
+
+/**
+ * Token information
+ */
+export type OAuth2Token = {
+
+  /**
+   * OAuth2 Access Token
+   */
+  accessToken: string;
+
+  /**
+   * When the Access Token expires.
+   *
+   * This is expressed as a unix timestamp in milliseconds.
+   */
+  expiresAt: number | null;
+
+  /**
+   * OAuth2 refresh token
+   */
+  refreshToken: string | null;
 };
+
+/**
+ * grant_type=password
+ */
+type PasswordGrantOptions = {
+  grantType: 'password';
+
+  /**
+   * OAuth2 client id
+   */
+  clientId: string;
+
+  /**
+   * OAuth2 Client Secret
+   */
+  clientSecret: string;
+
+  /**
+   * OAuth2 token endpoint
+   */
+  tokenEndpoint: string;
+
+  /**
+   * List of OAuth2 scopes
+   */
+  scope?: string[];
+
+  /**
+   * Username to log in as
+   */
+  userName: string;
+
+  /**
+   * Password
+   */
+  password: string;
+
+  /**
+   * Callback to trigger when a new access/refresh token pair was obtained.
+   */
+  onTokenUpdate?: (token: OAuth2Token) => void;
+
+  /**
+   * If authentication fails without a chance of recovery, this gets triggered.
+   *
+   * This is used for example when your resource server returns a 401, but only after
+   * other attempts have been made to reauthenticate (such as a token refresh).
+   */
+  onAuthError?: (error: Error) => void;
+};
+
+/**
+ * grant_type=client_credentials
+ */
+type ClientCredentialsGrantOptions = {
+  grantType: 'client_credentials';
+
+  /**
+   * OAuth2 client id
+   */
+  clientId: string;
+
+  /**
+   * OAuth2 Client Secret
+   */
+  clientSecret: string;
+
+  /**
+   * OAuth2 token endpoint
+   */
+  tokenEndpoint: string;
+
+  /**
+   * List of OAuth2 scopes
+   */
+  scope?: string[];
+
+  /**
+   * Callback to trigger when a new access/refresh token pair was obtained.
+   */
+  onTokenUpdate?: (token: OAuth2Token) => void;
+
+  /**
+   * If authentication fails without a chance of recovery, this gets triggered.
+   *
+   * This is used for example when your resource server returns a 401, but only after
+   * other attempts have been made to reauthenticate (such as a token refresh).
+   */
+  onAuthError?: (error: Error) => void;
+};
+
+/**
+ * grant_type=authorization_code
+ */
+type AuthorizationCodeGrantOptions = {
+  grantType: 'authorization_code';
+
+  /**
+   * OAuth2 client id
+   */
+  clientId: string;
+
+  /**
+   * OAuth2 token endpoint
+   */
+  tokenEndpoint: string;
+
+  /**
+   * The redirect_uri that was passed originally to the 'authorization' endpoint.
+   *
+   * This must be identical to the original string, as conforming OAuth2 servers
+   * will validate this.
+   */
+  redirectUri: string;
+
+  /**
+   * Code that was obtained from the authorization endpoint
+   */
+  code: string;
+
+  /**
+   * Callback to trigger when a new access/refresh token pair was obtained.
+   */
+  onTokenUpdate?: (token: OAuth2Token) => void;
+
+  /**
+   * If authentication fails without a chance of recovery, this gets triggered.
+   *
+   * This is used for example when your resource server returns a 401, but only after
+   * other attempts have been made to reauthenticate (such as a token refresh).
+   */
+  onAuthError?: (error: Error) => void;
+
+  /**
+   * When using PKCE, specify the previously generated code verifier here.
+   */
+  codeVerifier?: string;
+};
+
+/**
+ * In case you obtained an access token and/or refresh token through different
+ * means, you can not specify a grant_type and simply only specify an access
+ * and refresh token.
+ *
+ * If a refresh or tokenEndpoint are not supplied, the token will never get refreshed.
+ */
+type RefreshOnlyGrantOptions = {
+  grantType: undefined;
+
+  /**
+   * OAuth2 client id
+   */
+  clientId: string;
+  tokenEndpoint: string;
+
+  /**
+   * Callback to trigger when a new access/refresh token pair was obtained.
+   */
+  onTokenUpdate?: (token: OAuth2Token) => void;
+
+  /**
+   * If authentication fails without a chance of recovery, this gets triggered.
+   *
+   * This is used for example when your resource server returns a 401, but only after
+   * other attempts have been made to reauthenticate (such as a token refresh).
+   */
+  onAuthError?: (error: Error) => void;
+};
+
+export type OAuth2Options =
+  PasswordGrantOptions | ClientCredentialsGrantOptions | AuthorizationCodeGrantOptions | RefreshOnlyGrantOptions;


### PR DESCRIPTION
This new client has a lot more features. This PR creates a compatibility layer for the old API so nothing changes yet.

In the future the goal is to remove the @badgateway/oauth2-client dependency from ketting and only suggest it. The library itself has a way to create a ketting-compatibile middleware.