### PR TITLE
🩹 Fixing fetch-polyfill (`node-fetch`) according to the documentation

### DIFF
--- a/src/http/fetch-polyfill.ts
+++ b/src/http/fetch-polyfill.ts
@@ -5,8 +5,11 @@ import {
   Response,
 } from 'node-fetch';
 
-// Registering Fetch as a glboal polyfill
-(global as any).fetch = nodeFetch;
-(global as any).Request = Request;
-(global as any).Headers = Headers;
-(global as any).Response = Response;
+const globalThis = global as any;
+
+if (!globalThis.fetch) {
+  globalThis.fetch = nodeFetch;
+  globalThis.Request = Request;
+  globalThis.Headers = Headers;
+  globalThis.Response = Response;
+}


### PR DESCRIPTION
Hi !

### Context

* Node v16.15.0
* NextJS v13.1.2
* Typescript v4.6.4

### Problem

Failed to provide global access to fetch in NextJS. Because `global.fetch` is already defined, and is in read only mode.

```
TypeError: Cannot set property Request of #<Object> which has only a getter
```

### Solution

According to `node-fetch` documentation, simply adding a condition around the polyfill.

> Cf. https://github.com/node-fetch/node-fetch#providing-global-access
> ```js
> if (!globalThis.fetch) {
>   globalThis.fetch = fetch
>   globalThis.Headers = Headers
>   globalThis.Request = Request
>   globalThis.Response = Response
> }
> ```

Please, if you can merge this and release a new version of 7.x of `ketting` 🙏 

Many Thanks
Quentin