### PR TITLE
Synchronous `fromJSON` in hal

### DIFF
--- a/src/state/base-state.ts
+++ b/src/state/base-state.ts
@@ -226,6 +226,12 @@ export class BaseState<T> extends BaseHeadState implements State<T> {
 
   }
 
+  toJSON() {
+
+    return this.data;
+
+  }
+
   /**
    * Certain formats can embed other resources, identified by their
    * own URI.

--- a/src/state/interface.ts
+++ b/src/state/interface.ts
@@ -78,6 +78,11 @@ export type State<T = any> = {
   serializeBody(): Buffer|Blob|string;
 
   /**
+   * Returns a JSON of the state that can be used in a HTTP response.
+   */
+  toJSON(): any;
+
+  /**
    * Content-headers are a subset of HTTP headers that related directly
    * to the content. The obvious ones are Content-Type.
    *
@@ -116,7 +121,7 @@ export type State<T = any> = {
  * Some information in HEAD responses might be available, but many aren't.
  * Notably, the body.
  */
-export type HeadState = Omit<State, 'data' | 'action' | 'actions' | 'hasAction' | 'serializeBody' | 'getEmbedded' | 'client' | 'clone'>;
+export type HeadState = Omit<State, 'data' | 'action' | 'actions' | 'hasAction' | 'serializeBody' | 'toJSON' | 'getEmbedded' | 'client' | 'clone'>;
 
 /**
  * A 'StateFactory' is responsible for taking a Fetch Response, and returning

--- a/test/unit/state/hal.ts
+++ b/test/unit/state/hal.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { factory } from '../../../src/state/hal';
+import { factory, fromJSON } from '../../../src/state/hal';
 import { Client } from '../../../src';
 
 describe('HAL state factory', () => {
@@ -228,6 +228,38 @@ describe('HAL state factory', () => {
       },
       happy: 2020,
     });
+
+  });
+  it('should correctly rebuild HAL documents', async() => {
+
+    const base = {
+      _links: {
+        self: {
+          href: '/foo',
+        },
+        author: {
+          href: 'https://evertpot.com/',
+        },
+        foo: [
+          {
+            href: '/bar',
+          },
+          {
+            href: '/bar2',
+          },
+          {
+            href: '/bar3',
+          },
+        ]
+      },
+      happy: 2020,
+    };
+    const hal = await callFactory(base, base._links.self.href);
+    // const json = (hal as HalState).toJSON();
+    const json = hal.toJSON();
+    const result = fromJSON(hal.client, json);
+    expect(result.uri).to.eql(hal.uri);
+    expect(JSON.parse(result.serializeBody())).to.eql(base);
 
   });
   it('should handle JSON documents that are arrays', async () => {


### PR DESCRIPTION
Context : 
1. We are using Ketting in a Next.js application.
2. We do some data fetching using in `getStaticProps`, where props needs to be serializable. HalState is not as is.
3. We want to to convert a json in injected props by Next to synchronously populate the cache before rendering, so we need fromJSON to be sync (factory is async because of `await response.json()`).


We don't really need the changes in `base-state.ts` and `interface.ts`.


