### PR TITLE
Support `cache: no-store` when calling fetch().

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,8 +4,9 @@ ChangeLog
 8.0.0-alpha.3 (????-??-??)
 --------------------------
 
+* When `cache: no-store` is specified on `fetch()` functions, Ketting will now
+  no longer store responses with a `Content-Location` in its internal cache.
 * Testing Node 20.
-
 
 8.0.0-alpha.2 (2023-04-11)
 --------------------------

--- a/src/middlewares/cache.ts
+++ b/src/middlewares/cache.ts
@@ -70,7 +70,7 @@ export default function(client: Client): FetchMiddleware {
     // If the response had a 'Content-Location' header, it means that the
     // response body is the _new_ state for the url in the content-location
     // header, so we store it!
-    if (response.headers.has('Content-Location')) {
+    if (request.cache !== 'no-store' && response.headers.has('Content-Location')) {
       const cl = resolve(request.url, response.headers.get('Content-Location')!);
       const clState = await client.getStateForResponse(
         cl,

--- a/test/unit/resource-events.ts
+++ b/test/unit/resource-events.ts
@@ -207,6 +207,21 @@ describe('Resource Events', () => {
       expect(triggered).to.equal(true);
 
     });
+    it('should not trigger with Content-Location and cache: no-store', async() => {
+
+      const client = new Client('http://example');
+      client.use( mockFetchMw );
+      const resource = client.go('/res');
+      await resource.get();
+
+      let triggered = false;
+      resource.once('update', () => {
+        triggered = true;
+      });
+      await client.fetcher.fetch('http://example/content-location', { method: 'POST', cache: 'no-store' });
+      expect(triggered).to.equal(false);
+
+    });
   });
 
   describe('"delete" event', () => {


### PR DESCRIPTION
This solves one of the two problems in #474