### PR TITLE
Clone responses before reading when handing`Content-Location`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,9 +4,13 @@ ChangeLog
 8.0.0-alpha.3 (????-??-??)
 --------------------------
 
-* When `cache: no-store` is specified on `fetch()` functions, Ketting will now
-  no longer store responses with a `Content-Location` in its internal cache.
+* #476: When `cache: no-store` is specified on `fetch()` functions, Ketting
+  will now no longer store responses with a `Content-Location` in its internal
+  cache.
+* #477: When storing responses with `Content-Location`, bodies are now cloned
+  before storing so callees can still read the date.
 * Testing Node 20.
+
 
 8.0.0-alpha.2 (2023-04-11)
 --------------------------

--- a/src/middlewares/cache.ts
+++ b/src/middlewares/cache.ts
@@ -74,7 +74,7 @@ export default function(client: Client): FetchMiddleware {
       const cl = resolve(request.url, response.headers.get('Content-Location')!);
       const clState = await client.getStateForResponse(
         cl,
-        response
+        response.clone()
       );
       client.cacheState(clState);
     }


### PR DESCRIPTION
This solves 1 of the 2 issues of #474