### PR TITLE
Add Resources class for batch state fetching

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 export { default as Client, default as Ketting, default } from './client.js';
 export { default as Resource } from './resource.js';
 
+export { Resources } from './state/resources.js'
+
 export { type Link, LinkNotFound, Links, type LinkVariables } from './link.js';
 
 export { resolve } from './util/uri.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { default as Client, default as Ketting, default } from './client.js';
 export { default as Resource } from './resource.js';
 
-export { Resources } from './state/resources.js'
+export { Resources } from './state/resources.js';
 
 export { type Link, LinkNotFound, Links, type LinkVariables } from './link.js';
 

--- a/src/state/base-state.ts
+++ b/src/state/base-state.ts
@@ -1,4 +1,5 @@
 import { State, HeadState } from './interface.js';
+import { Resources } from './resources.js';
 import { Links, LinkVariables, LinkNotFound } from '../link.js';
 import Client from '../client.js';
 import { Action, ActionNotFound, ActionInfo, SimpleAction } from '../action.js';
@@ -99,19 +100,16 @@ export class BaseHeadState implements HeadState {
    *
    * If no resources were found, the array will be empty.
    */
-  followAll<TFollowedResource = any>(rel: string): Resource<TFollowedResource>[] {
-
-    return this.links.getMany(rel).map( link => {
-
+  followAll<TFollowedResource = any>(rel: string): Resources<TFollowedResource> {
+    const resources = this.links.getMany(rel).map( link => {
       if (link.hints?.status === 'deprecated') {
         /* eslint-disable-next-line no-console */
         console.warn(`[ketting] The ${link.rel} link on ${this.uri} is marked deprecated.`, link);
       }
       const href = resolve(link);
-      return this.client.go(href);
-
+      return this.client.go<TFollowedResource>(href);
     });
-
+    return new Resources(resources);
   }
 
 

--- a/src/state/interface.ts
+++ b/src/state/interface.ts
@@ -3,6 +3,7 @@ import { Links, LinkVariables } from '../link.js';
 import Client from '../client.js';
 import { Resource } from '../resource.js';
 import { StateSerializedBody } from '#state-serialized-body';
+import { Resources } from './resources.js';
 
 export type State<T = any> = {
 
@@ -48,7 +49,7 @@ export type State<T = any> = {
    *
    * If no resources were found, the array will be empty.
    */
-  followAll<TFollowedResource = any>(rel: string): Resource<TFollowedResource>[];
+  followAll<TFollowedResource = any>(rel: string): Resources<TFollowedResource>;
 
   /**
    * Return an action by name.

--- a/src/state/resources.ts
+++ b/src/state/resources.ts
@@ -1,0 +1,18 @@
+import {State} from './interface.js';
+import {Resource} from '../resource.js';
+
+export class Resources<T> extends Array<Resource<T>> {
+
+  static get [Symbol.species]() { return Array; }
+
+  constructor(resources: Resource<T>[]) {
+    super(resources.length);
+    resources.forEach((resource, index) => {
+      this[index] = resource;
+    });
+  }
+
+  public async get(): Promise<State<T>[]> {
+    return Promise.all(Array.from(this, resource => resource.get()));
+  }
+}

--- a/src/state/resources.ts
+++ b/src/state/resources.ts
@@ -1,0 +1,17 @@
+import { State } from './interface.js';
+import { Resource } from '../resource.js';
+import { GetRequestOptions } from '../types.js';
+
+export class Resources<T = any> extends Array<Resource<T>> {
+
+  static get [Symbol.species]() { return Array; }
+
+  constructor(resources: Resource<T>[]) {
+    super();
+    this.push(...resources);
+  }
+
+  public async get(getOptions?: GetRequestOptions): Promise<State<T>[]> {
+    return Promise.all(this.map(resource => resource.get(getOptions)));
+  }
+}

--- a/test/integration/follow-hal.test.ts
+++ b/test/integration/follow-hal.test.ts
@@ -96,6 +96,20 @@ describe('Following a link', async () => {
 
     });
 
+    it('should resolve states when .get() is called on the State#followAll() result', async ({testApplicationUris}) => {
+
+      const serverUri = testApplicationUris.createTenantUri();
+      const client = new Client(serverUri + '/hal1.json');
+
+      const collectionState = await client.follow('collection').get();
+
+      const items = await collectionState.followAll('item').get();
+      expect(items).to.have.length(2);
+      expect(isState(items[0])).to.eq(true);
+      expect(isState(items[1])).to.eq(true);
+
+    });
+
     it('should remember the type="" property for later usage', async ({testApplicationUris}) => {
 
       const serverUri = testApplicationUris.createTenantUri();

--- a/test/unit/state/resources.test.ts
+++ b/test/unit/state/resources.test.ts
@@ -14,6 +14,10 @@ describe('Resources', () => {
     const uris = resources.map(r => r.uri);
     expect(uris).to.eql(['/a', '/b']);
 
+    resources.push(getFakeResource('/c'));
+
+    expect(resources[2].uri).to.eql('/c');
+
   });
 
   it('should resolve all resources to their state when get() is called', async () => {

--- a/test/unit/state/resources.test.ts
+++ b/test/unit/state/resources.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from '#ketting-test';
+
+import { Resource, Links } from 'ketting';
+import { Resources } from '#ketting-dist/state/resources.js';
+
+describe('Resources', () => {
+
+  it('should behave like an Array', () => {
+
+    const fakeResources = [getFakeResource('/a'), getFakeResource('/b')];
+    const resources = new Resources(fakeResources);
+
+    expect(resources).to.be.an.instanceof(Array);
+    const uris = resources.map(r => r.uri);
+    expect(uris).to.eql(['/a', '/b']);
+
+  });
+
+  it('should resolve all resources to their state when get() is called', async () => {
+
+    const fakeResources = [getFakeResource('/a'), getFakeResource('/b')];
+    const resources = new Resources(fakeResources);
+
+    const states = await resources.get();
+    expect(states).to.have.length(2);
+    expect(states[0].uri).to.eql('/a');
+    expect(states[1].uri).to.eql('/b');
+
+  });
+
+  it('should return an empty array from get() when there are no resources', async () => {
+
+    const resources = new Resources([]);
+    const states = await resources.get();
+    expect(states).to.eql([]);
+
+  });
+
+});
+
+function getFakeResource(uri: string = 'https://example.org/') {
+
+  const fakeFetch = (input:any) => {
+    let url;
+    if (input.url) {
+      url = input.url;
+    } else {
+      url = input;
+    }
+    switch(url) {
+      case 'https://example.org/return-request':
+        return input;
+      case 'https://example.org/200':
+        return new Response('', {status: 200});
+      case 'https://example.org/201':
+        return new Response('', {status: 201});
+      case 'https://example.org/201-loc':
+        return new Response('', {status: 201, headers: { 'Location': 'https://evertpot.com/'}});
+      case 'https://example.org/205':
+        return new Response(null, {status: 205});
+    }
+  };
+
+  const fakeClient:any = {
+
+    fetcher: {
+
+      fetch: fakeFetch,
+      fetchOrThrow: fakeFetch,
+    },
+
+    go: (uri:string) => {
+
+      return getFakeResource(uri);
+
+    },
+
+    cache: {
+
+      get: ():null => { return null; },
+      store: ():void => { /* Intentionally Empty */ }
+
+    },
+
+    cacheState: (state: any) => {
+
+      return;
+
+    },
+
+    getStateForResponse: () => {
+
+      return {
+        uri,
+        links: new Links('/', [ { href: '/', rel: 'yes', context: '/' }])
+      };
+
+    }
+
+  };
+  const resource = new Resource(fakeClient, uri);
+  return resource;
+
+}


### PR DESCRIPTION
This fix #538

- Create Resources<T> class extending Array<Resource<T>>
- Add get() method to fetch all resource states in parallel
- Update followAll() return type from Resource[] to Resources
- Add unit tests for Resources class behavior